### PR TITLE
Added test button for client printers

### DIFF
--- a/RockLabelPrinter.cs
+++ b/RockLabelPrinter.cs
@@ -184,6 +184,25 @@ namespace CheckinClient
         }
 
         /// <summary>
+        /// Prints a test label to the chosen hardware printer.
+        /// </summary>
+        public void TestPrint()
+        {
+            var text = @"CT~~CD,~CC^~CT~
+^XA~TA000~JSN^LT0^MNW^MTD^PON^PMN^LH0,0^JMA^PR4,4~SD15^JUS^LRN^CI0^XZ
+^XA
+^MMT
+^PW609
+^LL0406
+^LS0
+^FT275,210^A0N,28,28^FH\^FDTEST^FS
+^PQ1,0,1,Y^XZ
+";
+            var rockConfig = RockConfig.Load();
+            RawPrinterHelper.SendStringToPrinter( rockConfig.PrinterOverrideLocal, text );
+        }
+
+        /// <summary>
         /// Prints the via ip.
         /// </summary>
         /// <param name="labelContents">The label contents.</param>

--- a/StartupPage.xaml
+++ b/StartupPage.xaml
@@ -52,6 +52,7 @@
                     <StackPanel x:Name="spUsbPrinterList" Orientation="Vertical">
                     </StackPanel>
                 </ScrollViewer>
+                <Button Content="Test Printer" x:Name="btnTest" Style="{StaticResource buttonStyleAction}" VerticalAlignment="Top" Width="280" Height="40" Margin="0,0,0,0" FontSize="18" Click="btnTest_Click"/>
             </StackPanel>
 
         </Grid>

--- a/StartupPage.xaml.cs
+++ b/StartupPage.xaml.cs
@@ -32,6 +32,30 @@ namespace CheckinClient
         public StartupPage()
         {
             InitializeComponent();
+
+            btnTest.Visibility = TestButtonVisiblity();
+        }
+
+        /// <summary>
+        /// Determines if the test button should be visible.
+        /// </summary>
+        /// <returns></returns>
+        private Visibility TestButtonVisiblity()
+        {
+            foreach ( Control control in spUsbPrinterList.Children )
+            {
+                if ( control is ToggleButton )
+                {
+                    ToggleButton tbControl = control as ToggleButton;
+                    if ( tbControl.IsChecked == true )
+                    {
+                        // show if a client printer is checked
+                        return Visibility.Visible;
+                    }
+                }
+            }
+            // don't show if no printer selected
+            return Visibility.Hidden;
         }
 
         /// <summary>
@@ -158,6 +182,37 @@ namespace CheckinClient
                     tbControl.IsChecked = false;
                 }
             }
+            btnTest.Visibility = TestButtonVisiblity();
+        }
+
+        /// <summary>
+        /// Handles the Click event of the btnTest control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="RoutedEventArgs"/> instance containing the event data.</param>
+        private void btnTest_Click( object sender, RoutedEventArgs e )
+        {
+            var rockConfig = RockConfig.Load();
+            rockConfig.PrinterOverrideIp = txtPrinterOverrideIp.Text;
+            rockConfig.PrinterOverrideLocal = string.Empty;
+
+            if ( txtPrinterOverrideIp.Text == string.Empty )
+            {
+                foreach ( Control control in spUsbPrinterList.Children )
+                {
+                    if ( control is ToggleButton )
+                    {
+                        ToggleButton tbControl = control as ToggleButton;
+                        if ( tbControl.IsChecked != null && tbControl.IsChecked.Value == true )
+                        {
+                            rockConfig.PrinterOverrideLocal = tbControl.Content.ToString();
+                        }
+                    }
+                }
+            }
+            rockConfig.Save();
+            var printer = new RockLabelPrinter();
+            printer.TestPrint();
         }
     }
 }


### PR DESCRIPTION
We had a lot of problems with our client printers not being selected. The issue is not noticed until someone goes to check-in. This feature has prevented a number of issues each weekend.

![capture](https://cloud.githubusercontent.com/assets/495787/20283066/82efc104-aa85-11e6-84b1-80f491fc939b.JPG)

