### PR TITLE
Fix for Windows 10

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -1,7 +1,8 @@
 ﻿<NavigationWindow x:Class="CheckinClient.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Rock Check-in Client" Height="350" Width="525" WindowState="Maximized" WindowStyle="None"
+        Title="Rock Check-in Client" Height="350" Width="525"
+        WindowState="Maximized" WindowStyle="None" ResizeMode="NoResize"
         FontFamily="./resources/#Open Sans Regular"
         Source="StartupPage.xaml" 
         ShowsNavigationUI="False">


### PR DESCRIPTION
In Windows 10 the taskbar shows even though the kiosk is full screen. This fixes that issue.