### PR TITLE
Added functionality to disable printing with a checkbox on the Startup Page

### DIFF
--- a/RockConfig.cs
+++ b/RockConfig.cs
@@ -196,6 +196,32 @@ namespace CheckinClient
         }
 
         /// <summary>
+        /// Gets or sets a value indicating whether the printer is disabled or not.
+        /// </summary>
+        /// <value>
+        /// <c>false</c> printing disabled; otherwise, <c>true</c>.
+        /// </value>
+        [DefaultSettingValueAttribute("false")]
+        [UserScopedSetting]
+        public bool IsPrintingDisabled
+        {
+            get
+            {
+                bool? isPrintingDisabled = this["IsPrintingDisabled"] as bool?;
+                if (!isPrintingDisabled.HasValue)
+                {
+                    isPrintingDisabled = true;
+                }
+
+                return isPrintingDisabled.Value;
+            }
+            set
+            {
+                this["IsPrintingDisabled"] = value;
+            }
+        }
+
+        /// <summary>
         /// Loads this instance.
         /// </summary>
         /// <returns></returns>

--- a/ScriptDirector.cs
+++ b/ScriptDirector.cs
@@ -18,6 +18,7 @@ namespace CheckinClient
         Page browserPage;
         ObjectCache cache;
         bool warnedPrinterError = false;
+        var rockConfig = RockConfig.Load();
 
         public ScriptDirector(Page p)
         {
@@ -26,8 +27,11 @@ namespace CheckinClient
         }
         public void PrintLabels(string tagJson)
         {
-            RockLabelPrinter printer = new RockLabelPrinter();
-            printer.PrintLabels( tagJson );
+            /* Checks if printer is enabled before printing. */
+            if (!rockConfig.IsPrintingDisabled) {
+                RockLabelPrinter printer = new RockLabelPrinter();
+                printer.PrintLabels( tagJson );
+            }
         }
 
         public void ErrorHandler(string message, string url, string lineNumber) {

--- a/StartupPage.xaml
+++ b/StartupPage.xaml
@@ -52,7 +52,7 @@
             </CheckBox>
             <TextBox x:Name="txtCacheLabelDuration" Style="{StaticResource textboxStyle}" Grid.Row="4" Grid.Column="2" Height="44" Width="100" HorizontalAlignment="Left" FontSize="24" Margin="0,15,0,0" Padding="4"></TextBox>
 
-            <StackPanel x:Name="spPrinterOverride" Orientation="Vertical" Grid.Row="6" Grid.Column="6" Height="400">
+            <StackPanel x:Name="spPrinterOverride" Orientation="Vertical" Grid.Row="6" Grid.Column="2" Height="400">
                 <TextBox x:Name="txtPrinterOverrideIp" Style="{StaticResource textboxStyle}" Height="44" Width="300" Margin="0,15,0,0" FontSize="24" Padding="4" ></TextBox>
                 <ScrollViewer CanContentScroll="True" HorizontalScrollBarVisibility="Hidden" VerticalScrollBarVisibility="Auto" Padding="20,20,20,20" MaxHeight="300">
                     <StackPanel x:Name="spUsbPrinterList" Orientation="Vertical">

--- a/StartupPage.xaml
+++ b/StartupPage.xaml
@@ -23,6 +23,7 @@
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
                 <RowDefinition Height="*" />
                 <RowDefinition Height="50" />
             </Grid.RowDefinitions>
@@ -34,18 +35,24 @@
             </Grid.ColumnDefinitions>
             <Label Content="Check-in Address" Style="{StaticResource labelStyle}" HorizontalAlignment="Right" VerticalAlignment="Top" Grid.Row="1" Grid.Column="1" FontSize="24" Margin="0,0,12,0"/>
             <Label Content="Enable Label Caching" Style="{StaticResource labelStyle}" HorizontalAlignment="Right" VerticalAlignment="Top" Grid.Row="2" Grid.Column="1" FontSize="24" Margin="0,15,12,0" />
-            <Label Content="Cache Duration" Style="{StaticResource labelStyle}" HorizontalAlignment="Right" VerticalAlignment="Top" Grid.Row="3" Grid.Column="1" FontSize="24" Margin="0,16,12,0" />
-            <Label Content="Printer Override" Style="{StaticResource labelStyle}" HorizontalAlignment="Right" VerticalAlignment="Top" Grid.Row="5" Grid.Column="1" FontSize="24" Margin="0,15,12,0"/>
+            <Label Content="Disable Printer" Style="{StaticResource labelStyle}" HorizontalAlignment="Right" VerticalAlignment="Top" Grid.Row="3" Grid.Column="1" FontSize="24" Margin="0,15,12,0" />
+            <Label Content="Cache Duration" Style="{StaticResource labelStyle}" HorizontalAlignment="Right" VerticalAlignment="Top" Grid.Row="4" Grid.Column="1" FontSize="24" Margin="0,16,12,0" />
+            <Label Content="Printer Override" Style="{StaticResource labelStyle}" HorizontalAlignment="Right" VerticalAlignment="Top" Grid.Row="6" Grid.Column="1" FontSize="24" Margin="0,15,12,0"/>
             <TextBox x:Name="txtCheckinAddress" Style="{StaticResource textboxStyleUrl}" Height="44" Grid.Row="1" Grid.Column="2" Width="520" FontSize="24" Margin="0" Padding="4" />
             <CheckBox x:Name="cbEnableLabelCaching" Grid.Column="2" HorizontalAlignment="Left" Grid.Row="2" FontSize="24" IsChecked="True" Margin="0,15,0,0" Height="16">
                 <CheckBox.LayoutTransform>
                     <ScaleTransform ScaleX="3" ScaleY="3" />
                 </CheckBox.LayoutTransform>
             </CheckBox>
-            <TextBox x:Name="txtCacheLabelDuration" Style="{StaticResource textboxStyle}" Grid.Row="3" Grid.Column="2" Height="44" Width="100" HorizontalAlignment="Left" FontSize="24" Margin="0,15,0,0" Padding="4"></TextBox>
+            <!-- Disable printer option -->
+            <CheckBox x:Name="cbDisablePrinter" Grid.Column="2" HorizontalAlignment="Left" Grid.Row="3" FontSize="24" IsChecked="False" Margin="0,15,0,0" Height="16">
+                <CheckBox.LayoutTransform>
+                    <ScaleTransform ScaleX="3" ScaleY="3" />
+                </CheckBox.LayoutTransform>
+            </CheckBox>
+            <TextBox x:Name="txtCacheLabelDuration" Style="{StaticResource textboxStyle}" Grid.Row="4" Grid.Column="2" Height="44" Width="100" HorizontalAlignment="Left" FontSize="24" Margin="0,15,0,0" Padding="4"></TextBox>
 
-
-            <StackPanel x:Name="spPrinterOverride" Orientation="Vertical" Grid.Row="5" Grid.Column="2" Height="400">
+            <StackPanel x:Name="spPrinterOverride" Orientation="Vertical" Grid.Row="6" Grid.Column="6" Height="400">
                 <TextBox x:Name="txtPrinterOverrideIp" Style="{StaticResource textboxStyle}" Height="44" Width="300" Margin="0,15,0,0" FontSize="24" Padding="4" ></TextBox>
                 <ScrollViewer CanContentScroll="True" HorizontalScrollBarVisibility="Hidden" VerticalScrollBarVisibility="Auto" Padding="20,20,20,20" MaxHeight="300">
                     <StackPanel x:Name="spUsbPrinterList" Orientation="Vertical">

--- a/StartupPage.xaml.cs
+++ b/StartupPage.xaml.cs
@@ -67,7 +67,7 @@ namespace CheckinClient
             }
 
             rockConfig.IsCachingEnabled = cbEnableLabelCaching.IsChecked.HasValue ? cbEnableLabelCaching.IsChecked.Value : true;
-
+            rockConfig.IsPrintingDisabled = cbDisablePrinter.IsChecked.HasValue ? cbDisablePrinter.IsChecked.Value : true;
             /*double zoomLevel;
             if (double.TryParse(txtZoomLevel.Text, out zoomLevel)) 
             {
@@ -122,6 +122,7 @@ namespace CheckinClient
             txtPrinterOverrideIp.Text = rockConfig.PrinterOverrideIp;
             txtCacheLabelDuration.Text = rockConfig.CacheLabelDuration.ToString();
             cbEnableLabelCaching.IsChecked = rockConfig.IsCachingEnabled;
+            cbDisablePrinter.IsChecked = rockConfig.IsPrintingDisabled;
             //txtZoomLevel.Text = rockConfig.ZoomLevel.ToString();
 
             string localPrinterName = rockConfig.PrinterOverrideLocal;


### PR DESCRIPTION
This functionality was needed because we have some campuses that print labels and some that don't.

We needed an option to allow certain campuses to disable printing, so that when they didn't have a printer plugged in, they would not get the error message "No printer has been configured."

