### PR TITLE
Merge pull request #5 from avodacs/develop

### DIFF
--- a/RockConfig.cs
+++ b/RockConfig.cs
@@ -61,6 +61,17 @@ namespace CheckinClient
                     checkinAddress = "http://yourserver.com/checkin";
                 }
 
+                // If a URL was provided in the Command Line, use it instead
+                string[] args = Environment.GetCommandLineArgs();
+
+                foreach (string arg in args)
+                {
+                    if (arg.StartsWith("/U:"))
+                    {
+                        checkinAddress = arg.Replace("/U:", "");
+                    }
+                }
+
                 return checkinAddress;
             }
 


### PR DESCRIPTION
Allows for a command line override of the URL.  Useful if you have shared Check-ins and would like to have multiple shortcuts that point to different Check-in URLs.

To use, add the argument: /U:<URL GOES HERE>